### PR TITLE
Revert "ci: upload coverage to sonarcloud"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
     branches:
       - master
 
@@ -52,13 +51,3 @@ jobs:
         env:
           PYTHONPATH: ..
         working-directory: tests
-
-      - name: Fix code coverage paths
-        run: |
-          sed -i 's/\/home\/runner\/work\/edgeql-qb\/edgeql-qb\//\/github\/workspace\//g' tests/artefacts/coverage.xml
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10-green.svg)](https://www.python.org/downloads/release/python-3100/)
-[![Tests](https://github.com/Pentusha/edgeql-qb/actions/workflows/tests.yml/badge.svg)](https://github.com/Pentusha/edgeql-qb/actions/workflows/tests.yml)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=Pentusha_edgeql-qb&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=Pentusha_edgeql-qb)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Pentusha_edgeql-qb&metric=coverage)](https://sonarcloud.io/summary/new_code?id=Pentusha_edgeql-qb)
 
 # EdgeQL Query Builder
 

--- a/edgeql_qb/frozendict.py
+++ b/edgeql_qb/frozendict.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-
 from collections.abc import Mapping
+
 from typing import Any, Iterator
 
 

--- a/edgeql_qb/render/pagination.py
+++ b/edgeql_qb/render/pagination.py
@@ -7,7 +7,7 @@ from edgeql_qb.func import FuncInvocation
 from edgeql_qb.render.query_literal import render_query_literal
 from edgeql_qb.render.tools import combine_many_renderers, join_renderers
 from edgeql_qb.render.types import RenderedQuery
-from edgeql_qb.types import int64, unsafe_text
+from edgeql_qb.types import unsafe_text, int64
 
 
 @singledispatch

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,0 @@
-sonar.projectKey=Pentusha_edgeql-qb
-sonar.organization=pentusha
-sonar.tests=tests/
-sonar.sources=edgeql_qb/
-sonar.python.xunit.reportPath=tests/artefacts/junit_report.xml
-sonar.python.coverage.reportPaths=tests/artefacts/coverage.xml
-sonar.python.version=3.10, 3.11


### PR DESCRIPTION
Reverts Pentusha/edgeql-qb#33 due dependencies error see: [github action run](https://github.com/Pentusha/edgeql-qb/actions/runs/3055388759)