### PR TITLE
Add python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [
     { include = "edgeql_qb" },


### PR DESCRIPTION
## Summary by Sourcery

Add support for Python 3.13 by updating the CI configuration and project metadata.

Enhancements:
- Update project metadata to include Python 3.13 as a supported version.

CI:
- Add Python 3.13 to the CI testing matrix to ensure compatibility.